### PR TITLE
Suppress console warnings for v2.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -97,7 +97,7 @@ const checkForSdkUpdates = async () => {
   try {
     const { response } = await RESTController.ajax(
       'GET',
-      'https://www.unpkg.com/moralis/package.json'
+      'https://www.unpkg.com/moralis-v1/package.json'
     );
     const latestVersion = response.version;
     const installedVersion = process.env.NEXT_VERSION;


### PR DESCRIPTION
---
name: 'Suppress v2 console warnings'
about: This package should not emit console warnings related to v2
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK-v1/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK-v1/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

<!-- Add a brief description of the issue this PR solves. -->

Related issue: #`FILL_THIS_OUT`

### Solution Description

Replace

```
https://www.unpkg.com/moralis-v1/package.json
```

with 

```
https://www.unpkg.com/moralis-v1/package.json
```

is `checkForSdkUpdates`.